### PR TITLE
Complete and Fix the SPANISH TRANSLATION on Setup

### DIFF
--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -1,7 +1,7 @@
 // This file is converted by code7bit.
 // code7bit: https://github.com/katahiromz/code7bit
 // To revert conversion, please execute "code7bit -r <file>".
-/* Translated by ??? and Ismael Ferreras Morezuelas (Swyter) */
+/* Translated by ??? and Ismael Ferreras Morezuelas (Swyter) revised in 2020 by Julen Urizar Compains*/
 
 #pragma once
 
@@ -17,21 +17,21 @@ static MUI_ENTRY esESSetupInitPageEntries[] =
     {
         0,
         20,
-        "Please wait while the ReactOS Setup initializes itself",
+        "Por favor, espere a que la instalaci\242n de ReactOS se inicie",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_CENTER,
         TEXT_ID_STATIC
     },
     {
         0,
         21,
-        "and discovers your devices...",
+        "y analice los dispositivos...",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_CENTER,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "Please wait...",
+        "Por favor, espere...",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -55,28 +55,28 @@ static MUI_ENTRY esESLanguagePageEntries[] =
     {
         6,
         8,
-        "Selecci\242n del idioma",
+        "Selecci\242n de idioma",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         10,
-        "\x07  Seleccione el idioma a utilizar durante la instalaci\242n.",
+        "\x07  Por favor, seleccione el idioma de la instalaci\242n.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "   Luego presione INTRO.",
+        "   Luego, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  El idioma seleccionado tambi\202n ser\240 el idioma del sistema.",
+        "\x07  El idioma seleccionado ser\240 el idioma del sistema.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -114,14 +114,14 @@ static MUI_ENTRY esESWelcomePageEntries[] =
     {
         6,
         11,
-        "Esta parte de la instalaci\242n copiar\240 ReactOS en su equipo y",
+        "Este paso de la instalaci\242n copiar\240 ReactOS en el equipo y",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "prepara la segunda parte de la instalaci\242n.",
+        "prepara el segundo paso de la instalaci\242n.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -135,21 +135,21 @@ static MUI_ENTRY esESWelcomePageEntries[] =
     {
         8,
         17,
-        "\x07  Presione R para reparar ReactOS.",
+        "\x07  Pulse R para reparar ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Presione L para ver las condiciones y t\202rminos de licencia.",
+        "\x07  Pulse L para leer los T\202rminos y Condiciones de la licencia.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Presione F3 para salir sin instalar ReactOS.",
+        "\x07  Pulse F3 para salir sin instalar ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -194,63 +194,63 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Version Status",
+        "Situaci\242n de la Versi\242n de ReactOS",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         6,
         11,
-        "ReactOS is in Alpha stage, meaning it is not feature-complete",
+        "ReactOS est\240 en fase Alpha, lo que significa que a\243n no est\240",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "and is under heavy development. It is recommended to use it only for",
+        "completo y est\240 bajo intenso desarrollo. Se recomienda su uso solo",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         13,
-        "evaluation and testing purposes and not as your daily-usage OS.",
+        "para hacer pruebas y testeos y no como un SO de uso diario.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         15,
-        "Backup your data or test on a secondary computer if you attempt",
+        "Haz copia de tus datos o prueba en un ordenador secundario",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         16,
-        "to run ReactOS on real hardware.",
+        "en caso de que pruebes ReactOS en hardware real.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Press ENTER to continue ReactOS Setup.",
+        "\x07  Pulse INTRO para continuar la instalaci\242n de ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Press F3 to quit without installing ReactOS.",
+        "\x07  Pulse F3 para salir sin instalar ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "ENTER = Continue   F3 = Quit",
+        "ENTER = Continuar   F3 = Salir",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -274,70 +274,70 @@ static MUI_ENTRY esESLicensePageEntries[] =
     {
         6,
         6,
-        "Licencia:",
+        "T\202rminos y Condiciones de la Licencia:",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         8,
         8,
-        "ReactOS se distribuye bajo los t\202rminos de la licencia",
+        "ReactOS se distribuye bajo los T\202rminos y Condiciones de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         9,
-        "GNU GPL con partes que contienen c\242digo de otras",
+        "la licencia GNU GPL, conteniendo secciones de c\242digo de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         10,
-        "licencias compatibles como la X11 o BSD y la GNU LGPL.",
+        "licencias compatibles como son X11, o BSD y la GNU LGPL.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "Todo el software que forma parte del sistema ReactOS est\240",
+        "Todo el software que forma parte del sistema ReactOS est\240,",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         12,
-        "por tanto liberado bajo licencia GNU GPL as\241 como manteniendo",
+        "por tanto, publicado bajo la licencia GNU GPL, as\241 como",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "la licencia original.",
+        "manteniendo la licencia original.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "Este software viene SIN GARANTIA o restricciones de uso",
+        "Este software NO TIENE GARANTIA ni restricciones de uso",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         16,
-        "excepto leyes locales o internacionales aplicables. La licencia",
+        "salvo las leyes locales e internacionales aplicables.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "de ReactOS cubre solo la distribuci\242n a terceras partes.",
+        "La licencia de ReactOS cubre solo la distribuci\242n a terceros.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -365,35 +365,35 @@ static MUI_ENTRY esESLicensePageEntries[] =
     {
         8,
         22,
-        "Garant\241a:",
+        "Garant\241as:",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         8,
         24,
-        "Este es un software libre; vea el c\242digo para las condiciones de copia.",
+        "Este es un software libre; lea el c\242digo para las condiciones de copia.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         25,
-        "No existe garant\241a; ni siquiera de MERCANTIBILIDAD",
+        "NO tiene garant\241a; ni siquiera MERCANTIL",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         26,
-        "o el cumplimiento de alg\243n prop\242sito particular",
+        "o de CUMPLIMIENTO DE PROP\340SITOS PARTICULARES",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "INTRO = Regresar",
+        "INTRO = Volver",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -417,7 +417,7 @@ static MUI_ENTRY esESDevicePageEntries[] =
     {
         6,
         8,
-        "La lista inferior muestra la configuraci\242n actual de dispositivos.",
+        "La siguiente lista muestra la configuraci\242n actual de dispositivos.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -445,7 +445,7 @@ static MUI_ENTRY esESDevicePageEntries[] =
     {
         24,
         14,
-        "Distrib. del teclado:",
+        "Distrib. de teclado:",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_RIGHT,
         TEXT_ID_STATIC
     },
@@ -465,35 +465,35 @@ static MUI_ENTRY esESDevicePageEntries[] =
     {
         6,
         19,
-        "Puede modificar la configuraci\242n con las teclas ARRIBA y ABAJO",
+        "Puede escoger la configuraci\242n de harware con las teclas",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         20,
-        "para elegir. Luego presione INTRO para cambiar a una configuraci\242n",
+        "ARRIBA y ABAJO. Luego, pulse INTRO para cambiar a una",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         21,
-        "alternativa.",
+        "configuraci\242n alternativa.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         23,
-        "Cuando la configuraci\242n sea correcta, elija \"Aceptar la configuraci\242n",
+        "Cuando la configuraci\242n sea la correcta, escoja \"Aceptar la configuraci\242n",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         24,
-        "de los dispostivos\" y presione INTRO.",
+        "de los dispostivos\" y pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -524,56 +524,56 @@ static MUI_ENTRY esESRepairPageEntries[] =
     {
         6,
         8,
-        "El instalador de ReactOS se encuentra en una etapa preliminar.",
+        "La instalaci\242n de ReactOS se encuentra en una fase preliminar.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         9,
-        "A\243n no posee todas las funciones de un instalador.",
+        "Todav\241a no posee todas las funciones de un instalador completo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "Las funciones de reparaci\242n no han sido a\243n implementadas.",
+        "Las funciones de reparaci\242n a\243n no han sido implementadas.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "\x07  Presione U para actualizar el sistema operativo.",
+        "\x07  Pulse U para actualizar el sistema operativo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "\x07  Presione R para la consola de recuperaci\242n.",
+        "\x07  Pulse R para abrir la consola de reparaci\242n.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Presione ESC para volver al men\243 principal.",
+        "\x07  Pulse ESC para volver al men\243 principal.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Presione INTRO para reiniciar su equipo.",
+        "\x07  Pulse INTRO para reiniciar el equipo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "ESC = Men\243 inicial  U = Actualizar  R = Recuperar  INTRO = Reiniciar",
+        "ESC = Men\243 inicial  U = Actualizar  R = Reparar  INTRO = Reiniciar",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -597,63 +597,63 @@ static MUI_ENTRY esESUpgradePageEntries[] =
     {
         6,
         8,
-        "The ReactOS Setup can upgrade one of the available ReactOS installations",
+        "El instalador puede actualizar una de las versiones de ReactOS",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         9,
-        "listed below, or, if a ReactOS installation is damaged, the Setup program",
+        "listadas a continuaci\242n o, si la instalaci\242n de ReactOS est\240 da\244ada,",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         10,
-        "can attempt to repair it.",
+        "puede intentar repararla.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "The repair functions are not all implemented yet.",
+        "Las funciones de reparaci\242n no est\240 implementadas todav\241a.",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "\x07  Press UP or DOWN to select an OS installation.",
+        "\x07  Pulse ARRIBA o ABAJO para elegir una instalaci\242n del SO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "\x07  Press U for upgrading the selected OS installation.",
+        "\x07  Pulse U para actualizar la instalaci\242n del SO elegida.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Press ESC to continue with a new installation.",
+        "\x07  Pulse ESC para continuar con una instalaci\242n nueva.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Press F3 to quit without installing ReactOS.",
+        "\x07  Pulse F3 para salir sin instalar ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "U = Upgrade   ESC = Do not upgrade   F3 = Quit",
+        "U = Actualizar   ESC = No actualizar   F3 = Salir",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -677,28 +677,28 @@ static MUI_ENTRY esESComputerPageEntries[] =
     {
         6,
         8,
-        "Desea modificar el tipo de equipo a instalar.",
+        "Desea modificar el tipo de equipo en el va a instalar el SO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         10,
-        "\x07  Presione ARRIBA y ABAJO para elegir el tipo.",
+        "\x07  Pulse ARRIBA y ABAJO para escoger el tipo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "Luego presione INTRO.",
+        "Luego, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  Presione ESC para volver a la p\240gina anterior sin cambiar",
+        "\x07  Pulse ESC para volver a la p\240gina anterior sin cambiar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -736,7 +736,7 @@ static MUI_ENTRY esESFlushPageEntries[] =
     {
         10,
         6,
-        "El sistema se est\240 asegurando que todos los datos sean salvados.",
+        "El sistema est\240 procurando almacenar todos los datos en el disco.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -750,7 +750,7 @@ static MUI_ENTRY esESFlushPageEntries[] =
     {
         10,
         9,
-        "Cuando haya terminado, su equipo se reiniciar\240 autom\240ticamente.",
+        "Cuando haya terminado, el equipo se reiniciar\240 autom\240ticamente.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -788,21 +788,21 @@ static MUI_ENTRY esESQuitPageEntries[] =
     {
         10,
         8,
-        "Retire cualquier disquete de la unidad A: y los CDs de sus unidades.",
+        "Retire cualquier disquete de la unidad A:",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         10,
         9,
-        "",
+        "y los CDs de sus respectivas unidades.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         10,
         11,
-        "Presione INTRO para reiniciar su equipo.",
+        "Pulse INTRO para reiniciar el equipo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -840,21 +840,21 @@ static MUI_ENTRY esESDisplayPageEntries[] =
     {
         8,
         10,
-         "\x07  Presione ARRIBA y ABAJO para modificar el tipo.",
+         "\x07  Pulse ARRIBA y ABAJO para modificar el tipo.",
          TEXT_STYLE_NORMAL,
          TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "   Luego presione INTRO.",
+        "   Luego, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  Presione la tecla ESC para volver a la p\240gina anterior sin",
+        "\x07  Pulse la tecla ESC para volver a la p\240gina anterior sin",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -899,28 +899,28 @@ static MUI_ENTRY esESSuccessPageEntries[] =
     {
         10,
         8,
-        "Retire cualquier disquete de la unidad A: y todos los",
+        "Retire cualquier disquete de la unidad A: y",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         10,
         9,
-        "CD-ROMs de sus respectivas unidades.",
+        "los CDs de sus respectivas unidades.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         10,
         11,
-        "Presione INTRO para reiniciar su equipo.",
+        "Pulse INTRO para reiniciar el equipo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "   INTRO = Reiniciar su equipo",
+        "   INTRO = Reiniciar el equipo",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -951,7 +951,7 @@ static MUI_ENTRY esESBootPageEntries[] =
     {
         6,
         9,
-        "de su equipo",
+        "duro del equipo",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -965,7 +965,7 @@ static MUI_ENTRY esESBootPageEntries[] =
     {
         6,
         14,
-        "presione INTRO.",
+        "Pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -997,64 +997,64 @@ static MUI_ENTRY esESSelectPartitionEntries[] =
     {
         6,
         8,
-        "La lista inferior muestra las particiones existentes y el espacio libre",
+        "La siguiente lista muestra las particiones existentes y el espacio",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         9,
-        "en el disco para nuevas particiones.",
+        "disponible en el disco para nuevas particiones.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "\x07  Presione ARRIBA o ABAJO para seleccionar un elemento de la lista.",
+        "\x07  Pulse ARRIBA o ABAJO para escoger un elemento de la lista.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  Presione INTRO para instalar ReactOS en la partici\242n seleccionada.",
+        "\x07  Pulse INTRO para instalar ReactOS en la Partici\242n seleccionada.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "\x07  Presione P para crear una partici\242n primaria.",
-//        "\x07  Presione C para crear una nueva partici¢n.",
+        "\x07  Pulse P para crear una Partici\242n Primaria.",
+//        "\x07  Pulse C para crear una Nueva Partici¢n.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "\x07  Presione E para crear una partici\242n extendida.",
+        "\x07  Pulse E para crear una Partici\242n Extendida.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Presione L para crear una partici\242n l\242gica.",
+        "\x07  Pulse L para crear una Partici\242n L\242gica.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Presione D para borrar una partici\242n existente.",
+        "\x07  Pulse D para eliminar una Partici\242n existente.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "Espere un momento...",
+        "Espere un momento, por favor...",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -1071,112 +1071,112 @@ static MUI_ENTRY esESChangeSystemPartition[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        " Instalaci\242n de ReactOS " KERNEL_VERSION_STR " ",
         TEXT_STYLE_UNDERLINE,
         TEXT_ID_STATIC
     },
     {
         6,
         8,
-        "The current system partition of your computer",
+        "El sistema de particiones escogido en el disco del sistema",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "on the system disk",
+        "de tu ordenador",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         16,
-        "uses a format not supported by ReactOS.",
+        "usa un formato que ReactOS no puede gestionar.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         18,
-        "In order to successfully install ReactOS, the Setup program must change",
+        "Para poder instalar correctamente ReactOS, el instalador deber\240 cambiar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         19,
-        "the current system partition to a new one.",
+        "el sistema actual de particiones por uno nuevo.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         21,
-        "The new candidate system partition is:",
+        "La propuesta de sistema de partici\242n es:",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         25,
-        "\x07  To accept this choice, press ENTER.",
+        "\x07  Para aceptar esta opci\242n, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         27,
-        "\x07  To manually change the system partition, press ESC to go back to",
+        "\x07  Para cambiar manualmente el sistema de pariciones, pulse ESC para volver atr\240s",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         28,
-        "   the partition selection list, then select or create a new system",
+        "   a la lista de selecci\242n de particiones, luego selecciona o crea un nuevo",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         29,
-        "   partition on the system disk.",
+        "   sistema de pariciones en el disco del sistema.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         32,
-        "In case there are other operating systems that depend on the original",
+        "En caso de que haya otro sistema operativo que depende del sistema",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         33,
-        "system partition, you may need to either reconfigure them for the new",
+        "original de particiones, probablemente necesite reconfigurarlo para",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         34,
-        "system partition, or you may need to change the system partition back",
+        "la nueva partici\242n de sistema, o quiz\240s volver al sistema de particiones",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         35,
-        "to the original one after finishing the installation of ReactOS.",
+        "original una vez haya finalizado la instalaci\242n de ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "ENTER = Continue   ESC = Cancel",
+        "INTRO = Continuar   ESC = Cancelar",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -1200,35 +1200,35 @@ static MUI_ENTRY esESConfirmDeleteSystemPartitionEntries[] =
     {
         6,
         8,
-        "Ha solicitado borrar la partici\242n del sistema.",
+        "Ha solicitado eliminar la Partici\242n de Sistema.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         10,
-        "Las particiones del sistema contienen programas de diagn\242stico y configuraci\242n",
+        "\220sta puede contener programas de diagn\242stico, configuraci\242n de dispositivos,",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         11,
-        "de dispositivos, para arrancar un sistema operativo (como ReactOS) u otros",
+        "software, sistemas de arranque de un sistema operativo (como ReactOS) u otros",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "programas fundamentales proporcionados por el fabricante de hardware.",
+        "programas fundamentales proporcionados por el fabricante del hardware.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         14,
-        "Borre particiones del sistema \243nicamente cuando est\202 seguro de que no",
+        "Elimine particiones del sistema \243nicamente si est\240 seguro de que no",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1242,7 +1242,7 @@ static MUI_ENTRY esESConfirmDeleteSystemPartitionEntries[] =
     {
         6,
         16,
-        "Cuando se elimina una partici\242n puede perder la posibilidad de arrancar el",
+        "Al eliminar una partici\242n puede perder la posibilidad de arrancar el",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1256,28 +1256,28 @@ static MUI_ENTRY esESConfirmDeleteSystemPartitionEntries[] =
     {
         8,
         20,
-        "\x07  Presione INTRO para borrar la partici\242n del sistema, se",
+        "\x07  Pulse INTRO para eliminar la Partici\242n del Sistema,",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "   volver\240 a pedir confirmaci\242n m\240s tarde.",
+        "   se le volver\240 a pedir confirmaci\242n m\240s tarde.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         24,
-        "\x07  Presione ESC para volver a la p\240gina anterior. Si lo hace ",
+        "\x07  Pulse ESC para volver a la p\240gina anterior. Si lo hace ",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         25,
-        "   la partici\242n no se borrar\240.",
+        "   la partici\242n no se eliminar\240.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1315,7 +1315,7 @@ static MUI_ENTRY esESFormatPartitionEntries[] =
     {
         6,
         10,
-        "El instalador formatear\240 la partici\242n. Presione INTRO para continuar.",
+        "El instalador formatear\240 la partici\242n. Pulse INTRO para continuar.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_FORMAT_PROMPT
     },
@@ -1353,28 +1353,28 @@ static MUI_ENTRY esESInstallDirectoryEntries[] =
     {
         6,
         9,
-        "Seleccione un directorio donde quiere que sea instalado ReactOS:",
+        "Seleccione el directorio donde quiere instalar ReactOS:",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         14,
-        "Para cambiar el directorio sugerido, presione RETROCESO para borrar",
+        "Para cambiar el directorio sugerido, Pulse RETROCESO para eliminar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         15,
-        "caracteres y escriba el directorio donde desea que ReactOS",
+        "car\240cteres y escriba el directorio donde quiere instalar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         16,
-        "sea instalado.",
+        "ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1405,14 +1405,14 @@ static MUI_ENTRY esESFileCopyEntries[] =
     {
         0,
         12,
-        "Espere un momento mientras el Instalador de ReactOS copia",
+        "Por favor, espere mientras el Instalador de ReactOS copia",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_CENTER,
         TEXT_ID_STATIC
     },
     {
         0,
         13,
-        "archivos en su carpeta de instalaci\242n de ReactOS.",
+        "los archivos en el directorio de ReactOS.",
         TEXT_STYLE_NORMAL | TEXT_ALIGN_CENTER,
         TEXT_ID_STATIC
     },
@@ -1450,7 +1450,7 @@ static MUI_ENTRY esESBootLoaderEntries[] =
     {
         6,
         8,
-        "A continuaci\242n el programa instalar\240 el cargador de arranque",
+        "En este paso, el instalador crear\240 el cargador de arranque",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1516,21 +1516,21 @@ static MUI_ENTRY esESKeyboardSettingsEntries[] =
     {
         8,
         10,
-        "\x07  Presione ARRIBA o ABAJO para seleccionar el tipo de teclado.",
+        "\x07  Pulse ARRIBA o ABAJO para seleccionar el tipo de teclado.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "   Luego presione INTRO.",
+        "   Luego, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  Presione la tecla ESC para volver a la p\240gina anterior sin cambiar",
+        "\x07  Pulse la tecla ESC para volver a la p\240gina anterior sin cambiar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1575,21 +1575,21 @@ static MUI_ENTRY esESLayoutSettingsEntries[] =
     {
         8,
         10,
-        "\x07  Presione ARRIBA o ABAJO para seleccionar la distribuci\242n de teclado",
+        "\x07  Pulse ARRIBA o ABAJO para seleccionar la distribuci\242n de teclado",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "    deseada. Luego presione INTRO.",
+        "    deseada. Luego, pulse INTRO.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "\x07  Presione la tecla ESC para volver a la p\240gina anterior sin cambiar",
+        "\x07  Pulse la tecla ESC para volver a la p\240gina anterior sin cambiar",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1628,7 +1628,7 @@ static MUI_ENTRY esESPrepareCopyEntries[] =
     {
         6,
         8,
-        "El programa prepara su equipo para copiar los archivos de ReactOS.",
+        "El instalador est\240 preparando el equipo para copiar los archivos de ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1660,25 +1660,25 @@ static MUI_ENTRY esESSelectFSEntries[] =
     {
         6,
         17,
-        "Seleccione un sistema de archivos de la lista inferior.",
+        "Seleccione un sistema de archivos de la siguiente lista.",
         0
     },
     {
         8,
         19,
-        "\x07  Presione ARRIBA o ABAJO para seleccionar el sistema de archivos.",
+        "\x07  Pulse ARRIBA o ABAJO para seleccionar el sistema de archivos.",
         0
     },
     {
         8,
         21,
-        "\x07  Presione INTRO para formatear partici\242n.",
+        "\x07  Pulse INTRO para formatear la Partici\242n.",
         0
     },
     {
         8,
         23,
-        "\x07  Presione ESC para seleccionar otra partici\242n.",
+        "\x07  Pulse ESC para seleccionar otra Partici\242n.",
         0
     },
     {
@@ -1708,14 +1708,14 @@ static MUI_ENTRY esESDeletePartitionEntries[] =
     {
         6,
         8,
-        "Ha elegido borrar la partici\242n",
+        "Ha elegido eliminar la partici\242n",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         18,
-        "\x07  Presione L para borrar la partici\242n.",
+        "\x07  Pulse L para eliminar la partici\242n.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -1729,14 +1729,14 @@ static MUI_ENTRY esESDeletePartitionEntries[] =
     {
         8,
         21,
-        "\x07  Presione ESC para cancelar.",
+        "\x07  Pulse ESC para cancelar.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "   L = Borrar partici\242n   ESC = Cancelar   F3 = Salir",
+        "   L = Eliminar partici\242n   ESC = Cancelar   F3 = Salir",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -1792,28 +1792,28 @@ MUI_ERROR esESErrorEntries[] =
         "equipo. Si cierra ahora el Instalador, necesitar\240\n"
         "ejecutarlo otra vez para instalar ReactOS.\n"
         "\n"
-        "  \x07  Presione INTRO para continuar con el instalador.\n"
-        "  \x07  Presione F3 para abandonar el instalador.",
+        "  \x07  Pulse INTRO para continuar con el instalador.\n"
+        "  \x07  Pulse F3 para abandonar el instalador.",
         "F3 = Salir  INTRO = Continuar"
     },
     {
         // ERROR_NO_BUILD_PATH
-        "Failed to build the installation paths for the ReactOS installation directory!\n"
-        "ENTER = Reboot computer"
+        "\255Error creando las rutas de instalaci\242n para el directorio de ReactOS!\n"
+        "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_SOURCE_PATH
-        "You cannot delete the partition containing the installation source!\n"
-        "ENTER = Reboot computer"
+        "\255No puede eliminar la partici\242n que contiene el instalador!\n"
+        "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_SOURCE_DIR
-        "You cannot install ReactOS within the installation source directory!\n"
-        "ENTER = Reboot computer"
+        "\255No puede instalar ReactOS dentro del directorio fuente!\n"
+        "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_NO_HDD
-        "El instalador no pudo encontrar un disco duro.\n",
+        "El instalador no pudo encontrar ning\243n disco duro.\n",
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1823,17 +1823,17 @@ MUI_ERROR esESErrorEntries[] =
     },
     {
         // ERROR_LOAD_TXTSETUPSIF
-        "El instalador fall\242 al cargar el archivo TXTSETUP.SIF.\n",
+        "El instalador fall\242 al cargar el archivo TXTSETUP.SIF .\n",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_CORRUPT_TXTSETUPSIF
-        "El instalador encontr\242 un archivo TXTSETUP.SIF corrupto.\n",
+        "El instalador encontr\242 corrupto el archivo TXTSETUP.SIF .\n",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_SIGNATURE_TXTSETUPSIF,
-        "El instalador encontr\242 una firma incorrecta en TXTSETUP.SIF.\n",
+        "El instalador encontr\242 una firma incorrecta en TXTSETUP.SIF .\n",
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1843,7 +1843,7 @@ MUI_ERROR esESErrorEntries[] =
     },
     {
         // ERROR_WRITE_BOOT,
-        "El instalador fall\242 al instalar el c\242digo de inicio %S en la partici\242n del sistema.",
+        "El instalador fall\242 al instalar el c\242digo de arranque %S en la Partici\242n del Sistema.",
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1871,10 +1871,10 @@ MUI_ERROR esESErrorEntries[] =
         "\255El instalador encontr\242 que al menos un disco duro contiene una tabla\n"
         "de partici\242n incompatible que no puede ser manejada correctamente!\n"
         "\n"
-        "Crear o borrar particiones puede destruir la tabla de particiones.\n"
+        "Crear o eliminar particiones puede destruir la tabla de particiones.\n"
         "\n"
-        "  \x07  Presione F3 para salir del instalador.\n"
-        "  \x07  Presione INTRO para continuar.",
+        "  \x07  Pulse F3 para salir del instalador.\n"
+        "  \x07  Pulse INTRO para continuar.",
         "F3 = Salir  INTRO = Continuar"
     },
     {
@@ -1882,24 +1882,24 @@ MUI_ERROR esESErrorEntries[] =
         "\255No puede crear una nueva partici\242n dentro\n"
         "de una partici\242n existente!\n"
         "\n"
-        "  * Presione cualquier tecla para continuar.",
+        "  * Pulse cualquier tecla para continuar.",
         NULL
     },
     {
         // ERROR_DELETE_SPACE,
-        "\255No se puede borrar un espacio de disco sin particionar!\n"
+        "\255No se puede eliminar un espacio de disco sin particionar!\n"
         "\n"
-        "  * Presione cualquier tecla para continuar.",
+        "  * Pulse cualquier tecla para continuar.",
         NULL
     },
     {
         // ERROR_INSTALL_BOOTCODE,
-        "El instalador fall\242 al instalar el c\242digo de inicio %S en la partici\242n del sistema.",
+        "El instalador fall\242 al instalar el c\242digo de arranque %S en la partici\242n del sistema.",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_NO_FLOPPY,
-        "No hay disco en la unidad A:.",
+        "No hay disquete en la unidad A:.",
         "INTRO = Continuar"
     },
     {
@@ -1914,37 +1914,37 @@ MUI_ERROR esESErrorEntries[] =
     },
     {
         // ERROR_IMPORT_HIVE,
-        "El instalador fall\242 al importar un archivo de la estructura.",
+        "El instalador fall\242 al importar un archivo de sub\240rbol.",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_FIND_REGISTRY
-        "El instalador fall\242 al buscar los archivos de datos registrados.",
+        "El instalador fall\242 al buscar los archivos de datos de Registro.",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_CREATE_HIVE,
-        "El instalador fall\242 al crear el registro de la estructura.",
+        "El instalador fall\242 al crear el sub\240rbol en el Registro.",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_INITIALIZE_REGISTRY,
-        "El instalador fall\242 al configurar el registro de inicio.",
+        "El instalador fall\242 al iniciar el Registro.",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_INVALID_CABINET_INF,
-        "Cabinet no tiene un archivo inf v\240lido.\n",
+        "El Gabinete -CAB- no tiene un archivo inf v\240lido.\n",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_CABINET_MISSING,
-        "Cabinet no encontrado.\n",
+        "No se encuentra Gabinete -CAB-.\n",
         "INTRO = Reiniciar el equipo"
     },
     {
         // ERROR_CABINET_SCRIPT,
-        "Cabinet no tiene ning\243n script de instalaci\242n.\n",
+        "El Gabinete -CAB- no tiene ning\243n script de instalaci\242n.\n",
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1966,7 +1966,7 @@ MUI_ERROR esESErrorEntries[] =
     {
         // ERROR_CABINET_SECTION,
         "El instalador fall\242 al buscar la secci\242n '%S'\n"
-        "en el cabinet.\n",
+        "en el Gabinete -CAB-.\n",
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1981,7 +1981,7 @@ MUI_ERROR esESErrorEntries[] =
     },
     {
         // ERROR_ADDING_CODEPAGE,
-        "El instalador fall\242 al a\244adir el c\242digo de p\240ginas al registro.\n"
+        "El instalador fall\242 al a\244adir el c\242digo de p\240ginas al Registro.\n"
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -1991,7 +1991,7 @@ MUI_ERROR esESErrorEntries[] =
     },
     {
         // ERROR_ADDING_KBLAYOUTS,
-        "El instalador no ha podido agregar los layouts de teclado al registro.\n"
+        "El instalador no ha podido agregar la distribuci\242n de teclado al Registro.\n"
         "INTRO = Reiniciar el equipo"
     },
     {
@@ -2003,28 +2003,28 @@ MUI_ERROR esESErrorEntries[] =
         // ERROR_DIRECTORY_NAME,
         "Nombre de carpeta no v\240lido.\n"
         "\n"
-        "  * Presione una tecla para continuar."
+        "  * Pulse una tecla para continuar."
     },
     {
         // ERROR_INSUFFICIENT_PARTITION_SIZE,
         "La partici\242n selecionada no es lo suficientemente grande como para.\n"
         "instalar ReactOS. Se necesita una partici\242n de al menos %lu MB.\n"
         "\n"
-        "  * Presione una tecla para continuar.",
+        "  * Pulse una tecla para continuar.",
         NULL
     },
     {
         // ERROR_PARTITION_TABLE_FULL,
-        "No es posible a\244adir una partici\242n primaria o extendida en la\n"
-        "tabla de partici\242n de este disco, ya que est\240 completamente llena.\n"
+        "No es posible a\244adir una Partici\242n Primaria o Extendida en la\n"
+        "tabla de particiones de este disco porque est\240 completamente llena.\n"
         "\n"
-        "  * Presione una tecla para continuar."
+        "  * Pulse una tecla para continuar."
     },
     {
         // ERROR_ONLY_ONE_EXTENDED,
-        "No es posible crear m\240s de una partici\242n extendida por disco.\n"
+        "No es posible crear m\240s de una Partici\242n Extendida por disco.\n"
         "\n"
-        "  * Presione una tecla para continuar."
+        "  * Pulse una tecla para continuar."
     },
     {
         // ERROR_FORMATTING_PARTITION,
@@ -2160,37 +2160,37 @@ MUI_STRING esESStrings[] =
     {STRING_PLEASEWAIT,
      "   Espere un momento..."},
     {STRING_INSTALLCREATEPARTITION,
-     "   INTRO = Instalar  P = Crear primaria   E = Crear extendida   F3 = Salir"},
+     "   INTRO = Instalar  P = Crear Primaria   E = Crear Extendida   F3 = Salir"},
     {STRING_INSTALLCREATELOGICAL,
-     "   INTRO = Instalar  C = Crear partici\242n l\242gica   F3 = Salir"},
+     "   INTRO = Instalar  C = Crear Partici\242n L\242gica   F3 = Salir"},
     {STRING_DELETEPARTITION,
-     "   D = Borrar partici\242n   F3 = Salir"},
+     "   D = Eliminar Partici\242n   F3 = Salir"},
     {STRING_INSTALLDELETEPARTITION,
-     "   INTRO = Instalar   D = Borrar partici\242n   F3 = Salir"},
+     "   INTRO = Instalar   D = Eliminar partici\242n   F3 = Salir"},
     {STRING_PARTITIONSIZE,
-     "Tama\244o de la nueva partici\242n:"},
+     "Tama\244o de la nueva Partici\242n:"},
     {STRING_CHOOSENEWPARTITION,
-     "Ha elegido crear una nueva partici\242n primaria en"},
+     "Ha elegido crear una nueva Partici\242n Primaria en"},
     {STRING_CHOOSE_NEW_EXTENDED_PARTITION,
-     "Ha elegido crear una nueva partici\242n extendida en"},
+     "Ha elegido crear una nueva Partici\242n Extendida en"},
     {STRING_CHOOSE_NEW_LOGICAL_PARTITION,
-     "Ha elegido crear una nueva partici\242n l\242gica en"},
+     "Ha elegido crear una nueva Partici\242n L\242gica en"},
     {STRING_HDDSIZE,
-    "Escriba el tama\244o de la nueva partici\242n en megabytes."},
+    "Escriba el tama\244o de la nueva Partici\242n en megabytes."},
     {STRING_CREATEPARTITION,
-     "   INTRO = Crear partici\242n   ESC = Cancelar   F3 = Salir"},
+     "   INTRO = Crear Partici\242n   ESC = Cancelar   F3 = Salir"},
     {STRING_PARTFORMAT,
     "A continuaci\242n se formatear\240 esta partici\242n."},
     {STRING_NONFORMATTEDPART,
-    "Ha elegido instalar ReactOS en una nueva partici\242n o en una partici\242n sin formato."},
+    "Ha elegido instalar ReactOS en una nueva Partici\242n o en una Partici\242n sin formato."},
     {STRING_NONFORMATTEDSYSTEMPART,
-    "La partici\242n del sistema todav\241a no ha sido formateada."},
+    "La Partici\242n del sistema todav\241a no ha sido formateada."},
     {STRING_NONFORMATTEDOTHERPART,
-    "La partici\242n nueva todav\241a no ha sido formateada."},
+    "La Partici\242n nueva todav\241a no ha sido formateada."},
     {STRING_INSTALLONPART,
-    "El instalador est\240 instalando ReactOS en la partici\242n"},
+    "El instalador est\240 instalando ReactOS en la Partici\242n"},
     {STRING_CHECKINGPART,
-    "El instalador est\240 comprobando la partici\242n seleccionada."},
+    "El instalador est\240 comprobando la Partici\242n seleccionada."},
     {STRING_CONTINUE,
     "INTRO = Continuar"},
     {STRING_QUITCONTINUE,
@@ -2198,11 +2198,11 @@ MUI_STRING esESStrings[] =
     {STRING_REBOOTCOMPUTER,
     "INTRO = Reiniciar el equipo"},
     {STRING_DELETING,
-     "   Deleting file: %S"},
+     "   Eliminando archivo: %S"},
     {STRING_MOVING,
-     "   Moving file: %S to: %S"},
+     "   Moviendo archivo: %S a: %S"},
     {STRING_RENAMING,
-     "   Renaming file: %S to: %S"},
+     "   Renombrando archivo: %S a: %S"},
     {STRING_COPYING,
      "   Copiando archivo: %S"},
     {STRING_SETUPCOPYINGFILES,
@@ -2224,13 +2224,13 @@ MUI_STRING esESStrings[] =
     {STRING_REBOOTCOMPUTER2,
     "   INTRO = Reiniciar el equipo"},
     {STRING_REBOOTPROGRESSBAR,
-    " Your computer will reboot in %li second(s)... "},
+    " Tu ordenador se reiniciar\240 en %li segundo(s)... "},
     {STRING_CONSOLEFAIL1,
     "No se pudo abrir la consola\r\n\r\n"},
     {STRING_CONSOLEFAIL2,
     "La causa m\240s com\243n es la utilizaci\242n de un teclado USB\r\n"},
     {STRING_CONSOLEFAIL3,
-    "Todav\241a no se soportan los teclados USB por completo\r\n"},
+    "Todav\241a no hay soporte del todo para los teclados USB\r\n"},
     {STRING_FORMATTINGDISK,
     "El instalador est\240 formateando el disco"},
     {STRING_CHECKINGDISK,
@@ -2242,29 +2242,29 @@ MUI_STRING esESStrings[] =
     {STRING_KEEPFORMAT,
     " Mantener el sistema de archivos actual (sin cambios) "},
     {STRING_HDINFOPARTCREATE_1,
-    "%I64u %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) en %wZ [%s]."},
+    "%I64u %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) en %wZ [%s]."},
     {STRING_HDINFOPARTCREATE_2,
-    "%I64u %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) [%s]."},
+    "%I64u %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) [%s]."},
     {STRING_HDDINFOUNK2,
     "   %c%c  Tipo 0x%02X    %I64u %s"},
     {STRING_HDINFOPARTDELETE_1,
-    "en %I64u %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) en %wZ [%s]."},
+    "en %I64u %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) en %wZ [%s]."},
     {STRING_HDINFOPARTDELETE_2,
-    "en %I64u %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) [%s]."},
+    "en %I64u %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) [%s]."},
     {STRING_HDINFOPARTZEROED_1,
-    "Disco duro %lu (%I64u %s), Port=%hu, Bus=%hu, Id=%hu (%wZ) [%s]."},
+    "Disco duro %lu (%I64u %s), Puerto=%hu, Bus=%hu, Id=%hu (%wZ) [%s]."},
     {STRING_HDDINFOUNK4,
     "%c%c  Tipo 0x%02X    %I64u %s"},
     {STRING_HDINFOPARTEXISTS_1,
-    "en Disco duro %lu (%I64u %s), Port=%hu, Bus=%hu, Id=%hu (%wZ) [%s]."},
+    "en Disco duro %lu (%I64u %s), Puerto=%hu, Bus=%hu, Id=%hu (%wZ) [%s]."},
     {STRING_HDDINFOUNK5,
     "%c%c %c %sTipo %-3u%s                      %6lu %s"},
     {STRING_HDINFOPARTSELECT_1,
-    "%6lu %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) en %wZ [%s]"},
+    "%6lu %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) en %wZ [%s]"},
     {STRING_HDINFOPARTSELECT_2,
-    "%6lu %s  Disco duro %lu  (Port=%hu, Bus=%hu, Id=%hu) [%s]"},
+    "%6lu %s  Disco duro %lu  (Puerto=%hu, Bus=%hu, Id=%hu) [%s]"},
     {STRING_NEWPARTITION,
-    "El instalador ha creado una nueva partici\242n en"},
+    "El instalador ha creado una nueva Partici\242n en"},
     {STRING_UNPSPACE,
     "    %sEspacio sin particionar%s            %6lu %s"},
     {STRING_MAXSIZE,
@@ -2276,7 +2276,7 @@ MUI_STRING esESStrings[] =
     {STRING_FORMATUNUSED,
     "Libre"},
     {STRING_FORMATUNKNOWN,
-    "desconocido"},
+    "Desconocido"},
     {STRING_KB,
     "KB"},
     {STRING_MB,


### PR DESCRIPTION
I've fixed the random names, fixed the technical terms, translated all the English words, and fixing random and incorrect denominations like "Cabinet" or "distribuciones".

## Purpose

To upgrade and improve the Spanish Setup translation file, that was outdated.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

- Change the es_ES.h



## TODO

_Use a TODO when your pull request is Work in Progress._

-  Setup Spanish translation done. [Done ] 
- Create the different dialects. [Work in progress ] 
- Create the other Spanish langs like Basque [Work in progress ] 
